### PR TITLE
lapimeti → lapimete（印刷上もそうなっている）

### DIFF
--- a/lauzait_cep/pemecepe.tsv
+++ b/lauzait_cep/pemecepe.tsv
@@ -91,7 +91,7 @@
 この際はボーナス点を得ず、勝利点のみを得ます。	jo kaleti nole nip cene letit kaceit zo leti atakecleti kin pi letit molkait leti kin.
 勝利点一覧	molkait leti kin leti auc
 ラウツァイト・セプ	lauzait cep!
-専門家委員会	lapimeti cet
+専門家委員会	lapimete cet
 全ての駒が同じ色	auclt zo e nuwaxeclt dec
 大行列	xep laiju
 9個の連続する数	9lt laijult kin


### PR DESCRIPTION
規範的には lapimete で、印刷もそうなっているので、tsv だけを直せばよい